### PR TITLE
Fixing the hyperlink to Azure FastTrack landing page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FastTrack for Azure
 
-See our [FastTrack for Azure landing page](https://github.com/Azure/FastTrackForAzure) for more information.
+See our [FastTrack for Azure landing page](https://azure.microsoft.com/programs/azure-fasttrack/partners) for more information.
 
 # Cloud Native Apps Scenarios
 

--- a/containerizeecommercesite/README.md
+++ b/containerizeecommercesite/README.md
@@ -1,6 +1,6 @@
 # FastTrack for Azure
 
-See our [FastTrack for Azure landing page](https://github.com/Azure/FastTrackForAzure) for more information.
+See our [FastTrack for Azure landing page](https://azure.microsoft.com/programs/azure-fasttrack/partners/) for more information.
 
 
 # Containerized E-Commerce Site

--- a/ecommerce/README.md
+++ b/ecommerce/README.md
@@ -1,6 +1,6 @@
 # FastTrack for Azure
 
-See our [FastTrack for Azure landing page](https://github.com/Azure/FastTrackForAzure) for more information.
+See our [FastTrack for Azure landing page](https://azure.microsoft.com/programs/azure-fasttrack/partners) for more information.
 
 
 # E-commerce


### PR DESCRIPTION
Fixing the hyperlink to Azure FastTrack landing page, in the README files.